### PR TITLE
Expand console prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="zh-cn">
+<head>
+<meta charset="UTF-8">
+<title>多角色平台控制台示例</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="login">
+    <h2>选择角色登录</h2>
+    <select id="roleSelect">
+      <option value="admin">平台管理员</option>
+      <option value="pm">项目经理</option>
+      <option value="architect">系统架构师</option>
+      <option value="sim">仿真工程师</option>
+      <option value="model">建模工程师</option>
+    </select>
+    <button onclick="login()">登录</button>
+  </div>
+
+<div id="console" class="hidden">
+  <header>
+    <h1 id="roleTitle"></h1>
+    <div>
+      <span id="messageCenter" onclick="toggleMessages()">消息(0)</span>
+      <button id="logout" onclick="logout()">退出</button>
+    </div>
+  </header>
+  <div id="messages" class="hidden">
+    <h3>消息中心</h3>
+    <ul id="messageList"></ul>
+    <button onclick="closeMessages()">关闭</button>
+  </div>
+  <div class="layout">
+    <nav id="sidebar"></nav>
+    <main id="main"></main>
+    <aside id="extra"></aside>
+  </div>
+  <footer id="statusBar">系统正常运行</footer>
+</div>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,97 @@
+const roleConfig = {
+  admin: {
+    title: '平台管理员',
+    sidebar: ['系统监控','成员管理','角色分配'],
+    messages: ['系统已更新','有新的用户申请'],
+    extra: '系统日志\n安全审计'
+  },
+  pm: {
+    title: '项目经理',
+    sidebar: ['项目总览','任务燃尽','资源面板'],
+    messages: ['项目A 截止日期临近','请检查资源分配'],
+    extra: '提醒中心'
+  },
+  architect: {
+    title: '系统架构师',
+    sidebar: ['项目列表','架构编辑','版本比对'],
+    messages: ['模型库更新','请同步最新需求'],
+    extra: 'SSP 导出'
+  },
+  sim: {
+    title: '仿真工程师',
+    sidebar: ['仿真任务','流程编辑','结果面板'],
+    messages: ['仿真B 运行完成','诊断报告生成'],
+    extra: '仿真助手'
+  },
+  model: {
+    title: '建模工程师',
+    sidebar: ['建模任务','模型库','上传工具'],
+    messages: ['新的模型任务分配'],
+    extra: '快速建模模板'
+  }
+};
+
+function login() {
+  const role = document.getElementById('roleSelect').value;
+  showConsole(role);
+}
+
+function showConsole(role) {
+  const cfg = roleConfig[role];
+  document.getElementById('login').classList.add('hidden');
+  document.getElementById('console').classList.remove('hidden');
+  document.getElementById('roleTitle').textContent = cfg.title + ' 控制台';
+  buildSidebar(cfg);
+  createModules(cfg);
+  document.getElementById('extra').textContent = cfg.extra;
+  const msgs = cfg.messages || [];
+  document.getElementById('messageCenter').textContent = `消息(${msgs.length})`;
+  document.getElementById('messageList').innerHTML = msgs.map(m=>`<li>${m}</li>`).join('');
+}
+
+function buildSidebar(cfg) {
+  const sb = document.getElementById('sidebar');
+  sb.innerHTML = '';
+  cfg.sidebar.forEach(name => {
+    const div = document.createElement('div');
+    const chk = document.createElement('input');
+    chk.type = 'checkbox';
+    chk.checked = true;
+    chk.onchange = () => toggleModule(name, chk.checked);
+    div.appendChild(chk);
+    const span = document.createElement('span');
+    span.textContent = ' ' + name;
+    div.appendChild(span);
+    sb.appendChild(div);
+  });
+}
+
+function createModules(cfg) {
+  const main = document.getElementById('main');
+  main.innerHTML = '';
+  cfg.sidebar.forEach(name => {
+    const sec = document.createElement('section');
+    sec.id = 'mod-' + name;
+    sec.textContent = name + ' 内容区域';
+    main.appendChild(sec);
+  });
+}
+
+function toggleModule(name, show) {
+  const id = 'mod-' + name;
+  const el = document.getElementById(id);
+  if (el) el.style.display = show ? 'block' : 'none';
+}
+
+function toggleMessages() {
+  document.getElementById('messages').classList.toggle('hidden');
+}
+
+function closeMessages() {
+  document.getElementById('messages').classList.add('hidden');
+}
+
+function logout() {
+  document.getElementById('console').classList.add('hidden');
+  document.getElementById('login').classList.remove('hidden');
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,9 @@
+body { font-family: Arial, sans-serif; margin: 0; }
+header { background: #333; color: #fff; padding: 10px; display: flex; justify-content: space-between; align-items: center; }
+.layout { display: flex; height: calc(100vh - 100px); }
+#sidebar { width: 200px; background: #f2f2f2; padding: 10px; overflow-y: auto; }
+#main { flex: 1; padding: 10px; overflow-y: auto; }
+#extra { width: 200px; background: #fafafa; padding: 10px; overflow-y: auto; }
+#messages { position: fixed; top: 60px; right: 20px; background: #fff; border: 1px solid #ccc; padding: 10px; width: 250px; box-shadow: 0 2px 8px rgba(0,0,0,0.2); }
+#statusBar { background: #eee; padding: 5px 10px; text-align: right; font-size: 12px; }
+.hidden { display: none; }


### PR DESCRIPTION
## Summary
- update `index.html` with a message center overlay and logout button
- expand `style.css` for the messages panel and footer
- enhance `script.js` to load role messages and allow hiding widgets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68590c7cdb388333a29a7a520a333a62