### PR TITLE
Add role based dashboard demo

### DIFF
--- a/frontend/src/components/layouts/DashboardLayout.jsx
+++ b/frontend/src/components/layouts/DashboardLayout.jsx
@@ -1,0 +1,17 @@
+export default function DashboardLayout({ sidebar, children }) {
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <aside
+        style={{
+          width: '200px',
+          borderRight: '1px solid #ccc',
+          padding: '1rem',
+          boxSizing: 'border-box',
+        }}
+      >
+        {sidebar}
+      </aside>
+      <main style={{ flex: 1, overflow: 'auto', padding: '1rem' }}>{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/components/layouts/Sidebar.jsx
+++ b/frontend/src/components/layouts/Sidebar.jsx
@@ -1,0 +1,11 @@
+export default function Sidebar({ items }) {
+  return (
+    <ul style={{ listStyle: 'none', padding: 0 }}>
+      {items.map((it) => (
+        <li key={it} style={{ marginBottom: '0.5rem' }}>
+          {it}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/layouts/TopBar.jsx
+++ b/frontend/src/components/layouts/TopBar.jsx
@@ -1,0 +1,17 @@
+export default function TopBar({ role }) {
+  return (
+    <div
+      style={{
+        height: '50px',
+        borderBottom: '1px solid #ccc',
+        padding: '0 1rem',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+      }}
+    >
+      <span>控制台</span>
+      <span>当前角色: {role}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/widgets/ArchitectureEditor.jsx
+++ b/frontend/src/components/widgets/ArchitectureEditor.jsx
@@ -1,0 +1,8 @@
+export default function ArchitectureEditor() {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+      <h3>架构模型编辑器</h3>
+      <p>支持多种 SysML 图的编辑。</p>
+    </div>
+  );
+}

--- a/frontend/src/components/widgets/ModelTaskBoard.jsx
+++ b/frontend/src/components/widgets/ModelTaskBoard.jsx
@@ -1,0 +1,8 @@
+export default function ModelTaskBoard() {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+      <h3>建模任务板</h3>
+      <p>管理和跟踪建模任务进度。</p>
+    </div>
+  );
+}

--- a/frontend/src/components/widgets/ProjectOverview.jsx
+++ b/frontend/src/components/widgets/ProjectOverview.jsx
@@ -1,0 +1,8 @@
+export default function ProjectOverview() {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+      <h3>项目总览</h3>
+      <p>展示负责或参与的项目概况。</p>
+    </div>
+  );
+}

--- a/frontend/src/components/widgets/ReminderCenter.jsx
+++ b/frontend/src/components/widgets/ReminderCenter.jsx
@@ -1,0 +1,8 @@
+export default function ReminderCenter() {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+      <h3>提醒中心</h3>
+      <p>聚合未读提醒和待处理事项。</p>
+    </div>
+  );
+}

--- a/frontend/src/components/widgets/SimulationPanel.jsx
+++ b/frontend/src/components/widgets/SimulationPanel.jsx
@@ -1,0 +1,8 @@
+export default function SimulationPanel() {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+      <h3>仿真控制台</h3>
+      <p>配置并触发仿真任务，查看结果。</p>
+    </div>
+  );
+}

--- a/frontend/src/components/widgets/SystemMonitor.jsx
+++ b/frontend/src/components/widgets/SystemMonitor.jsx
@@ -1,0 +1,8 @@
+export default function SystemMonitor() {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+      <h3>平台健康监控</h3>
+      <p>这里展示系统日志、资源占用等信息。</p>
+    </div>
+  );
+}

--- a/frontend/src/components/widgets/UserManager.jsx
+++ b/frontend/src/components/widgets/UserManager.jsx
@@ -1,0 +1,8 @@
+export default function UserManager() {
+  return (
+    <div style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+      <h3>用户与角色管理</h3>
+      <p>管理平台用户及其角色分配。</p>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDashboardConfig.js
+++ b/frontend/src/hooks/useDashboardConfig.js
@@ -1,0 +1,5 @@
+import roleMap from '../utils/roleMap';
+
+export default function useDashboardConfig(role) {
+  return roleMap[role] || [];
+}

--- a/frontend/src/hooks/useRole.js
+++ b/frontend/src/hooks/useRole.js
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export default function useRole() {
+  const [role, setRole] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('role');
+    setRole(stored || 'admin');
+  }, []);
+
+  return role;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,12 +4,16 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 import App from './App.jsx';
 import AppView from './AppView.jsx';
+import Login from './pages/Login.jsx';
+import Dashboard from './pages/Dashboard.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<App />} />
+        <Route path="/" element={<Login />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/designer" element={<App />} />
         <Route path="/app" element={<AppView />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,24 @@
+import useRole from '../hooks/useRole';
+import useDashboardConfig from '../hooks/useDashboardConfig';
+import DashboardLayout from '../components/layouts/DashboardLayout';
+import Sidebar from '../components/layouts/Sidebar';
+import TopBar from '../components/layouts/TopBar';
+
+export default function Dashboard() {
+  const role = useRole();
+  const widgets = useDashboardConfig(role);
+
+  if (!role) return null;
+
+  return (
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <TopBar role={role} />
+      <DashboardLayout sidebar={<Sidebar items={widgets.map((w) => w.label)} />}> 
+        {widgets.map((w) => {
+          const Comp = w.component;
+          return <Comp key={w.label} />;
+        })}
+      </DashboardLayout>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const roles = [
+  { label: '平台管理员', value: 'admin' },
+  { label: '项目经理', value: 'pm' },
+  { label: '系统架构师', value: 'arch' },
+  { label: '仿真工程师', value: 'sim' },
+  { label: '建模工程师', value: 'model' },
+];
+
+export default function Login() {
+  const [role, setRole] = useState('admin');
+  const navigate = useNavigate();
+
+  const handleLogin = () => {
+    localStorage.setItem('role', role);
+    navigate('/dashboard');
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>选择角色登录</h2>
+      <select value={role} onChange={(e) => setRole(e.target.value)}>
+        {roles.map((r) => (
+          <option key={r.value} value={r.value}>
+            {r.label}
+          </option>
+        ))}
+      </select>
+      <button onClick={handleLogin} style={{ marginLeft: '1rem' }}>
+        登录
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/utils/roleMap.js
+++ b/frontend/src/utils/roleMap.js
@@ -1,0 +1,29 @@
+import SystemMonitor from '../components/widgets/SystemMonitor';
+import UserManager from '../components/widgets/UserManager';
+import ProjectOverview from '../components/widgets/ProjectOverview';
+import ReminderCenter from '../components/widgets/ReminderCenter';
+import ArchitectureEditor from '../components/widgets/ArchitectureEditor';
+import SimulationPanel from '../components/widgets/SimulationPanel';
+import ModelTaskBoard from '../components/widgets/ModelTaskBoard';
+
+const roleMap = {
+  admin: [
+    { label: '平台健康监控', component: SystemMonitor },
+    { label: '用户与角色管理', component: UserManager },
+  ],
+  pm: [
+    { label: '项目总览', component: ProjectOverview },
+    { label: '提醒中心', component: ReminderCenter },
+  ],
+  arch: [
+    { label: '架构模型编辑器', component: ArchitectureEditor },
+  ],
+  sim: [
+    { label: '仿真控制台', component: SimulationPanel },
+  ],
+  model: [
+    { label: '建模任务板', component: ModelTaskBoard },
+  ],
+};
+
+export default roleMap;


### PR DESCRIPTION
## Summary
- create login page to select user role
- show a dashboard with widgets depending on role
- add placeholder widgets and simple layout components
- wire new routes in `main.jsx`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d4e60a88c83338702fb821b589db8