### PR TITLE
Add sub-node detail view and tool data selector

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import 'reactflow/dist/style.css';
 import { initialNodes, initialEdges } from './workflowData';
 import './App.css';
 import SubWorkflow from './components/SubWorkflow.jsx';
+import ToolDataSelector from './components/ToolDataSelector.jsx';
 
 const statusColors = {
   pending: '#f0f0f0',
@@ -121,6 +122,11 @@ function App() {
     setToolData([]);
   };
 
+  const handleSelectSubNode = (sub) => {
+    setSelectedSub({ id: sub.id, data: { label: sub.label } });
+    setToolData([]);
+  };
+
   const onSubNodeClick = (_e, node) => {
     setSelectedSub(node);
   };
@@ -130,7 +136,7 @@ function App() {
       const res = await fetch(api);
       const data = await res.json();
       setToolData(data.items || data);
-    } catch (e) {
+    } catch {
       // fallback demo data
       setToolData([{ id: 1, name: '示例数据' }]);
     }
@@ -186,10 +192,55 @@ function App() {
                   checked={sn.active}
                   onChange={() => toggleSubNode(selected.id, sn.id)}
                 />
-                {sn.label}
-                {sn.required ? ' (必选)' : ''}
+                <span
+                  onClick={() => handleSelectSubNode(sn)}
+                  style={{ cursor: 'pointer', marginLeft: '4px' }}
+                >
+                  {sn.label}
+                  {sn.required ? ' (必选)' : ''}
+                </span>
               </label>
             ))}
+            {selectedSub && (
+              <div style={{ borderTop: '1px solid #ddd', paddingTop: '0.5rem' }}>
+                <h4>{selectedSub.data.label} 配置</h4>
+                {selected.data.subNodes
+                  .find((sn) => sn.id === selectedSub.id)
+                  ?.config?.tool && (
+                  <div>
+                    <p>
+                      外部工具:{' '}
+                      {
+                        selected.data.subNodes.find((sn) => sn.id === selectedSub.id)
+                          .config.tool
+                      }
+                    </p>
+                    <button
+                      onClick={() =>
+                        window.open(
+                          selected.data.subNodes.find((sn) => sn.id === selectedSub.id)
+                            .config.link,
+                          '_blank'
+                        )
+                      }
+                    >
+                      打开工具
+                    </button>
+                    <button
+                      onClick={() =>
+                        fetchToolData(
+                          selected.data.subNodes.find((sn) => sn.id === selectedSub.id)
+                            .config.restApi
+                        )
+                      }
+                    >
+                      解析内容
+                    </button>
+                    {toolData.length > 0 && <ToolDataSelector data={toolData} />}
+                  </div>
+                )}
+              </div>
+            )}
             <button onClick={openSubWorkflow}>查看子节点视图</button>
             <button onClick={() => startFromNode(selected)}>从此处开始执行</button>
           </div>

--- a/frontend/src/components/ToolDataSelector.jsx
+++ b/frontend/src/components/ToolDataSelector.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+export default function ToolDataSelector({ data }) {
+  const [selectedItems, setSelectedItems] = useState([]);
+
+  const toggle = (item) => {
+    setSelectedItems((prev) =>
+      prev.includes(item) ? prev.filter((i) => i !== item) : [...prev, item]
+    );
+  };
+
+  return (
+    <div
+      style={{
+        border: '1px solid #ccc',
+        padding: '0.5rem',
+        marginTop: '0.5rem',
+        maxHeight: '150px',
+        overflowY: 'auto',
+      }}
+    >
+      {data.map((d) => (
+        <label key={d.id || d.name} style={{ display: 'block' }}>
+          <input
+            type="checkbox"
+            checked={selectedItems.includes(d)}
+            onChange={() => toggle(d)}
+          />
+          {d.name || d.id}
+        </label>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show sub-node configuration in sidebar
- allow opening external tools and parsing REST API data
- add reusable `ToolDataSelector` component

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e135fc01c8333b47d65da1ccc47bb